### PR TITLE
Fix AConnect(Key) not working if `GetAsyncKeyState` only returns `0x8000`

### DIFF
--- a/inc/avz_connector.h
+++ b/inc/avz_connector.h
@@ -151,10 +151,13 @@ template <typename Op>
 AConnectHandle AConnect(AKey key, Op&& op, int priority = 0, int runMode = ATickRunner::GLOBAL) {
     if (__AKeyManager::ToValidKey(key) != __AKeyManager::VALID)
         return AConnectHandle();
-    auto keyFunc = [key]() -> bool {
+    auto wasPressed = std::make_shared<bool>(false);
+    auto keyFunc = [key, wasPressed]() -> bool {
+        bool isPressed = (GetAsyncKeyState(key) & 0x8000) == 0x8000;
+        bool activate = isPressed && !*wasPressed;
+        *wasPressed = isPressed;
         auto pvzHandle = AGetPvzBase()->MRef<HWND>(0x350);
-        return ((GetAsyncKeyState(key) & 0x8001) == 0x8001 && //
-            GetForegroundWindow() == pvzHandle);              // 检测 pvz 是否为顶层窗口
+        return (activate && GetForegroundWindow() == pvzHandle);              // 检测 pvz 是否为顶层窗口
     };
     auto handle = AConnect(std::move(keyFunc), std::forward<Op>(op), runMode, priority);
     __AKeyManager::AddKey(key, handle);


### PR DESCRIPTION
The least significant bit on the return value of `GetAsyncKeyState` is not reliable, see https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getasynckeystate#remarks

Not sure what the root cause is, but in my testing,  `GetAsyncKeyState` started returning `0x8000` on Windows >= build 26200